### PR TITLE
add a notebook parsing bitcointicker and selecting data for annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,4 @@ cython_debug/
 .DS_Store
 *.pkl
 *.joblib
-data/20190110_train_4500.csv
+data/*.csv

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Fixed cross-validation folds for experiments: `data/folds.csv`, [notebook](noteb
 Learning curves built for the baseline model: [task](https://www.notion.so/a74951e4e815480584dea7d61ddce6cc?v=dbfdb1207d0e451b827d3c5041ed0cfd&p=41d93e8bcd0a47949d0ed92f0f6592eb), [notebook](notebooks/20220408_btc_4500_titles_logit_tfidf_learning_curves.ipynb). Adding new labeled data helps.
 
 <img src="figures/20220408_learning_curves_baseline_model_4500_titles.png" width=70% />
+
+[This notebook](notebooks/20220413_scrape_bitcointicker_news_prepare_batches_for_annotation.ipynb) scrapes [https://bitcointicker.co/news](https://bitcointicker.co/news/) (Selenium + BeautifulSoup) and examines prediction entropy which is a way to distinguish easy and hard examples. 

--- a/notebooks/20220413_scrape_bitcointicker_news_prepare_batches_for_annotation.ipynb
+++ b/notebooks/20220413_scrape_bitcointicker_news_prepare_batches_for_annotation.ipynb
@@ -1,0 +1,1334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Author\n",
+    "Yury Kashnitsky\n",
+    "\n",
+    "#### Reference\n",
+    "[Notion ticket](https://www.notion.so/a74951e4e815480584dea7d61ddce6cc?v=dbfdb1207d0e451b827d3c5041ed0cfd&p=4cc8d88f4a1349d7bcdf9be55724d4cf)\n",
+    "\n",
+    "#### Idea\n",
+    "Scrape https://bitcointicker.co/news/ and run the model against this data to select diverse examples (when the model is very confident and when it's lost) to be annotated with Amazon Mechanical Turk. \n",
+    "\n",
+    "#### Results\n",
+    " - 3250 news titles are saved locally. Of those 2 batches, each of 200 records, are selected for annotation.\n",
+    " - Filtering based on presence of at least one verb seems to make sense\n",
+    " - Prediction entropy works well to distinguish easy and hard examples but some hard examples seem to be rubbish"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scraping bitcointicker.co – the easy way (only 50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "pd.set_option('display.max_colwidth', 0)\n",
+    "import requests\n",
+    "from bs4 import BeautifulSoup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "URL = 'https://bitcointicker.co/news/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "page = requests.get(URL)\n",
+    "soup = BeautifulSoup(page.content, 'html.parser')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parsed_titles = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for el in soup.find_all('div', attrs={'style': \"overflow:hidden;\"}):\n",
+    "    news = el.get_text().split(' - ')[0].strip()\n",
+    "    parsed_titles.append(news)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "50"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(parsed_titles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Green Bitcoin mining proof of concept using Tesla solar and battery storage',\n",
+       " 'Why bitcoin ETFs are grounded',\n",
+       " 'Steps On To Open A Bitcoin Account In Nigeria',\n",
+       " \"Twitter Founder Jack Dorsey's Bitcoin Obsession, Explained\",\n",
+       " 'Cryptocurrency Prices Today April 13: Bitcoin edges down, Binance Coin biggest gainer']"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parsed_titles[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scraping bitcointicker.co – the harder way\n",
+    "\n",
+    "[Tutorial](https://medium.com/analytics-vidhya/using-python-and-selenium-to-scrape-infinite-scroll-web-pages-825d12c24ec7)\n",
+    "\n",
+    "Prereqs:\n",
+    " - [chromedriver](https://chromedriver.chromium.org/downloads) (for Mac - `brew install chromedriver`)\n",
+    " - `pip install selenium`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/xs/x4nxtnxd4qq06sg5z0x951q1q7mkqq/T/ipykernel_51105/937507031.py:8: DeprecationWarning: executable_path has been deprecated, please pass in a Service object\n",
+      "  driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3250 titles parsed from https://bitcointicker.co/news/ in 300 secs.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from selenium import webdriver\n",
+    "\n",
+    "CHROMEDRIVER_PATH = \"/usr/local/bin/chromedriver\"\n",
+    "TOTAL_PARSING_TIME = 300 # secs to parse, still to figure out how to change to the number of elements parsed\n",
+    "\n",
+    "# Web scrapper for infinite scrolling page \n",
+    "driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH)\n",
+    "driver.get(URL)\n",
+    "time.sleep(2)  # Allow 2 seconds for the web page to open\n",
+    "scroll_pause_time = 1 # You can set your own pause time. \n",
+    "screen_height = driver.execute_script(\"return window.screen.height;\")   # get the screen height of the web\n",
+    "i = 1\n",
+    "start_time = time.time()\n",
+    "\n",
+    "while True:\n",
+    "    # scroll one screen height each time\n",
+    "    driver.execute_script(\"window.scrollTo(0, {screen_height}*{i});\".format(screen_height=screen_height, i=i))  \n",
+    "    i += 1\n",
+    "    time.sleep(scroll_pause_time)\n",
+    "    # update scroll height each time after scrolled, as the scroll height can change after we scrolled the page\n",
+    "    scroll_height = driver.execute_script(\"return document.body.scrollHeight;\")  \n",
+    "    # Break the loop when the height we need to scroll to is larger than the total scroll height\n",
+    "#     if (screen_height) * i > scroll_height * 1.1:\n",
+    "#         break\n",
+    "    if time.time() - start_time > TOTAL_PARSING_TIME:\n",
+    "        break\n",
+    "        \n",
+    "parsed_titles = []\n",
+    "soup = BeautifulSoup(driver.page_source, \"html.parser\")\n",
+    "for el in soup.find_all('div', attrs={'style': \"overflow:hidden;\"}):\n",
+    "    title = el.get_text().split(' - ')[0].strip()\n",
+    "    parsed_titles.append(title)\n",
+    "    \n",
+    "print(f\"{len(parsed_titles)} titles parsed from {URL} in {TOTAL_PARSING_TIME} secs.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filtering the news: Selecting only news with a verb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df = pd.DataFrame({'Title': parsed_titles})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nltk\n",
+    "\n",
+    "def tag_verb_nltk(sent):\n",
+    "    # Doesn't work well\n",
+    "    # https://stackoverflow.com/questions/52324004/how-to-check-presense-of-verb-using-spacy-and-pandas\n",
+    "    words = nltk.word_tokenize(sent)\n",
+    "    tags = nltk.pos_tag(words)\n",
+    "    \n",
+    "    verb_found = False\n",
+    "    for t in tags:\n",
+    "        if t[1] == 'VB':\n",
+    "            verb_found = True\n",
+    "            \n",
+    "    return verb_found"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import spacy\n",
+    "nlp = spacy.load('en_core_web_sm')\n",
+    "\n",
+    "def tag_verb_spacy(sent):\n",
+    "    # https://ashutoshtripathi.com/2020/04/13/parts-of-speech-tagging-and-dependency-parsing-using-spacy-nlp/\n",
+    "    doc = nlp(sent)\n",
+    "    \n",
+    "    verb_found = False\n",
+    "    for t in doc:\n",
+    "        if t.pos_ == 'VERB':\n",
+    "            verb_found = True\n",
+    "            \n",
+    "    return verb_found"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df['has_verb'] = test_df['Title'].apply(lambda x: tag_verb_spacy(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Title</th>\n",
+       "      <th>has_verb</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Green Bitcoin mining proof of concept using Tesla solar and battery storage</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Why bitcoin ETFs are grounded</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Steps On To Open A Bitcoin Account In Nigeria</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Twitter Founder Jack Dorsey's Bitcoin Obsession, Explained</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Cryptocurrency Prices Today April 13: Bitcoin edges down, Binance Coin biggest gainer</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Here's where LFG's sustained acquisition of Bitcoin is leaving LUNA</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>ETF bigwigs gather as assets explode and a bitcoin fund remains a no-go</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>North Dakota aims to draw Bitcoin miners with promise of world’s ‘cleanest crypto’</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>No Bitcoin: Mozilla will only accept Proof of Stake crypto donations</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>This bullish setup puts Bitcoin price at $50,000 in the next week</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                    Title  \\\n",
+       "0   Green Bitcoin mining proof of concept using Tesla solar and battery storage             \n",
+       "1   Why bitcoin ETFs are grounded                                                           \n",
+       "2   Steps On To Open A Bitcoin Account In Nigeria                                           \n",
+       "3   Twitter Founder Jack Dorsey's Bitcoin Obsession, Explained                              \n",
+       "4   Cryptocurrency Prices Today April 13: Bitcoin edges down, Binance Coin biggest gainer   \n",
+       "6   Here's where LFG's sustained acquisition of Bitcoin is leaving LUNA                     \n",
+       "7   ETF bigwigs gather as assets explode and a bitcoin fund remains a no-go                 \n",
+       "8   North Dakota aims to draw Bitcoin miners with promise of world’s ‘cleanest crypto’      \n",
+       "9   No Bitcoin: Mozilla will only accept Proof of Stake crypto donations                    \n",
+       "10  This bullish setup puts Bitcoin price at $50,000 in the next week                       \n",
+       "\n",
+       "    has_verb  \n",
+       "0   True      \n",
+       "1   True      \n",
+       "2   True      \n",
+       "3   True      \n",
+       "4   True      \n",
+       "6   True      \n",
+       "7   True      \n",
+       "8   True      \n",
+       "9   True      \n",
+       "10  True      "
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df[test_df['has_verb']].head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Title</th>\n",
+       "      <th>has_verb</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Blackrock, Fidelity to Invest in Crypto Firm Circle's $400 Million Funding Round – Finance Bitcoin News</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>Bitcoin’s price history: 2009 to 2022</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>Best Bitcoin Mining Sites for 2022</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>Best Bitcoin Mining Software in 2022</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>37</th>\n",
+       "      <td>Robinhood Lists Shiba Inu and 3 More Cryptocurrencies — SHIB Price Soars – Altcoins Bitcoin News</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>43</th>\n",
+       "      <td>Bitcoin: Problems and Prospects | Cato at Liberty Blog</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>46</th>\n",
+       "      <td>8 Bitcoin Facts: Why is This Cryptocurrency Bad for The Environment?</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47</th>\n",
+       "      <td>Bitcoin Is Venice: Capitalism Without Capitalists</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>48</th>\n",
+       "      <td>90% Vote for SHIB vs. BTC in Recent Poll by Bitcoin of America ATM Chain</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>54</th>\n",
+       "      <td>Bearish Investors: Bitcoin Records $132M Weekly Outflow</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                                      Title  \\\n",
+       "5   Blackrock, Fidelity to Invest in Crypto Firm Circle's $400 Million Funding Round – Finance Bitcoin News   \n",
+       "27  Bitcoin’s price history: 2009 to 2022                                                                     \n",
+       "29  Best Bitcoin Mining Sites for 2022                                                                        \n",
+       "35  Best Bitcoin Mining Software in 2022                                                                      \n",
+       "37  Robinhood Lists Shiba Inu and 3 More Cryptocurrencies — SHIB Price Soars – Altcoins Bitcoin News          \n",
+       "43  Bitcoin: Problems and Prospects | Cato at Liberty Blog                                                    \n",
+       "46  8 Bitcoin Facts: Why is This Cryptocurrency Bad for The Environment?                                      \n",
+       "47  Bitcoin Is Venice: Capitalism Without Capitalists                                                         \n",
+       "48  90% Vote for SHIB vs. BTC in Recent Poll by Bitcoin of America ATM Chain                                  \n",
+       "54  Bearish Investors: Bitcoin Records $132M Weekly Outflow                                                   \n",
+       "\n",
+       "    has_verb  \n",
+       "5   False     \n",
+       "27  False     \n",
+       "29  False     \n",
+       "35  False     \n",
+       "37  False     \n",
+       "43  False     \n",
+       "46  False     \n",
+       "47  False     \n",
+       "48  False     \n",
+       "54  False     "
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df[~test_df['has_verb']].head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df.to_csv('../data/20220413_parsed_3250_bitcointicker_titles.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Examples having at least one verb make more sense as \"news\" - we'll further work only with those."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df_filtered = test_df[test_df['has_verb']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2452"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(test_df_filtered)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading the model\n",
+    "We'd like to select examples for annotation based on prediction entropy, to select examples which the model struggles to classify. The model is trained in notebook `20220411_btc_4500_titles_fix_folds_for_validations.ipynb` or in [this repo](https://github.com/crypto-sentiment/crypto_sentiment_model_fast_api)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import joblib\n",
+    "\n",
+    "model = joblib.load('../models/tf-idf-logreg-baseline.joblib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making predictions for the crawled titles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.stats import entropy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/xs/x4nxtnxd4qq06sg5z0x951q1q7mkqq/T/ipykernel_51105/232991880.py:1: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  test_df_filtered['predicted_sentiment'] = model.predict(test_df_filtered[\"Title\"])\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_df_filtered['predicted_sentiment'] = model.predict(test_df_filtered[\"Title\"])\n",
+    "pred_probs = model.predict_proba(test_df_filtered[\"Title\"])\n",
+    "\n",
+    "# prediction entropy\n",
+    "pred_entropy = entropy(pred_probs, axis=1)\n",
+    "\n",
+    "# merging test data with pred probs and entropy\n",
+    "test_df_filtered = pd.concat([test_df_filtered, \n",
+    "                              pd.DataFrame(pred_probs, columns=model.named_steps['logit'].classes_,\n",
+    "                                          index=test_df_filtered.index)],\n",
+    "                            axis=1)\n",
+    "test_df_filtered['pred_entropy'] = pred_entropy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Positive    1491\n",
+       "Negative    713 \n",
+       "Neutral     248 \n",
+       "Name: predicted_sentiment, dtype: int64"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df_filtered['predicted_sentiment'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Title</th>\n",
+       "      <th>has_verb</th>\n",
+       "      <th>predicted_sentiment</th>\n",
+       "      <th>Negative</th>\n",
+       "      <th>Neutral</th>\n",
+       "      <th>Positive</th>\n",
+       "      <th>pred_entropy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Green Bitcoin mining proof of concept using Tesla solar and battery storage</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.396809</td>\n",
+       "      <td>0.220477</td>\n",
+       "      <td>0.382714</td>\n",
+       "      <td>1.067708</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Why bitcoin ETFs are grounded</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.192555</td>\n",
+       "      <td>0.180867</td>\n",
+       "      <td>0.626578</td>\n",
+       "      <td>0.919406</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Steps On To Open A Bitcoin Account In Nigeria</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.061937</td>\n",
+       "      <td>0.033662</td>\n",
+       "      <td>0.904400</td>\n",
+       "      <td>0.377326</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Twitter Founder Jack Dorsey's Bitcoin Obsession, Explained</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Neutral</td>\n",
+       "      <td>0.381594</td>\n",
+       "      <td>0.436436</td>\n",
+       "      <td>0.181971</td>\n",
+       "      <td>1.039544</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Cryptocurrency Prices Today April 13: Bitcoin edges down, Binance Coin biggest gainer</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.423398</td>\n",
+       "      <td>0.031271</td>\n",
+       "      <td>0.545332</td>\n",
+       "      <td>0.802909</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                   Title  \\\n",
+       "0  Green Bitcoin mining proof of concept using Tesla solar and battery storage             \n",
+       "1  Why bitcoin ETFs are grounded                                                           \n",
+       "2  Steps On To Open A Bitcoin Account In Nigeria                                           \n",
+       "3  Twitter Founder Jack Dorsey's Bitcoin Obsession, Explained                              \n",
+       "4  Cryptocurrency Prices Today April 13: Bitcoin edges down, Binance Coin biggest gainer   \n",
+       "\n",
+       "   has_verb predicted_sentiment  Negative   Neutral  Positive  pred_entropy  \n",
+       "0  True      Negative            0.396809  0.220477  0.382714  1.067708      \n",
+       "1  True      Positive            0.192555  0.180867  0.626578  0.919406      \n",
+       "2  True      Positive            0.061937  0.033662  0.904400  0.377326      \n",
+       "3  True      Neutral             0.381594  0.436436  0.181971  1.039544      \n",
+       "4  True      Positive            0.423398  0.031271  0.545332  0.802909      "
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df_filtered.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at examples with highest prediction entropy, these are uncertain cases.\n",
+    "\n",
+    "Observations:\n",
+    " - some titles are indeed hard: \"Bitcoin, Ethereum transaction fees drop 90% becoming cheaper to use\" (both \"fees\" and \"drop\" seem to be negative but \"fees drop\" is actually positive) and the model would benefit a lot from labeling such cases\n",
+    " - some examples are rubbish, not \"news\" or neutral news, e.g. \"Intel's Second-Gen Bitcoin Miner's Performance and Pricing Listed\", \"Trust Through Verification: The Establishment’s Nightmare\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Title</th>\n",
+       "      <th>has_verb</th>\n",
+       "      <th>predicted_sentiment</th>\n",
+       "      <th>Negative</th>\n",
+       "      <th>Neutral</th>\n",
+       "      <th>Positive</th>\n",
+       "      <th>pred_entropy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2845</th>\n",
+       "      <td>Intel's Second-Gen Bitcoin Miner's Performance and Pricing Listed</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.332262</td>\n",
+       "      <td>0.329662</td>\n",
+       "      <td>0.338076</td>\n",
+       "      <td>1.098557</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3140</th>\n",
+       "      <td>LIVE BLOG: Stocks, Bitcoin volatile amid Russia-Ukraine tensions, oil, natural gas jumps</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.345230</td>\n",
+       "      <td>0.320690</td>\n",
+       "      <td>0.334080</td>\n",
+       "      <td>1.098159</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>226</th>\n",
+       "      <td>\"There Will Be Many Things You Did Not Predict\": Jordan Peterson Critiques Bitcoin at Bitcoin 2022</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.330857</td>\n",
+       "      <td>0.321662</td>\n",
+       "      <td>0.347481</td>\n",
+       "      <td>1.098100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1822</th>\n",
+       "      <td>Bitcoin, Ethereum transaction fees drop 90% becoming cheaper to use</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.322409</td>\n",
+       "      <td>0.328323</td>\n",
+       "      <td>0.349268</td>\n",
+       "      <td>1.098018</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3143</th>\n",
+       "      <td>Cardano is 47,000x more energy-efficient than Bitcoin, data shows</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Neutral</td>\n",
+       "      <td>0.317704</td>\n",
+       "      <td>0.348848</td>\n",
+       "      <td>0.333448</td>\n",
+       "      <td>1.097884</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2618</th>\n",
+       "      <td>CryptoWorldCon, the Largest Conference Focused on Blockchain, Crypto, NFT, Metaverse, Bitcoin, Will Be Happening in Miami</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Neutral</td>\n",
+       "      <td>0.336844</td>\n",
+       "      <td>0.349672</td>\n",
+       "      <td>0.313485</td>\n",
+       "      <td>1.097597</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1766</th>\n",
+       "      <td>Bitcoin could form the backbone for CBDCs, according to a new report</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.315996</td>\n",
+       "      <td>0.329612</td>\n",
+       "      <td>0.354392</td>\n",
+       "      <td>1.097481</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1869</th>\n",
+       "      <td>Trust Through Verification: The Establishment’s Nightmare</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.329217</td>\n",
+       "      <td>0.315983</td>\n",
+       "      <td>0.354800</td>\n",
+       "      <td>1.097450</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2170</th>\n",
+       "      <td>Why Bitcoin- And Ethereum-Related Stock Marqeta Is Skyrocketing During Wednesday's After-Hours Session</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Neutral</td>\n",
+       "      <td>0.316709</td>\n",
+       "      <td>0.356757</td>\n",
+       "      <td>0.326534</td>\n",
+       "      <td>1.097316</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3220</th>\n",
+       "      <td>Bitcoin and Stock Futures Feel Choppy Following Heightened Russia-Ukraine Dispute</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Neutral</td>\n",
+       "      <td>0.311400</td>\n",
+       "      <td>0.355290</td>\n",
+       "      <td>0.333310</td>\n",
+       "      <td>1.097167</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                                                          Title  \\\n",
+       "2845  Intel's Second-Gen Bitcoin Miner's Performance and Pricing Listed                                                           \n",
+       "3140  LIVE BLOG: Stocks, Bitcoin volatile amid Russia-Ukraine tensions, oil, natural gas jumps                                    \n",
+       "226   \"There Will Be Many Things You Did Not Predict\": Jordan Peterson Critiques Bitcoin at Bitcoin 2022                          \n",
+       "1822  Bitcoin, Ethereum transaction fees drop 90% becoming cheaper to use                                                         \n",
+       "3143  Cardano is 47,000x more energy-efficient than Bitcoin, data shows                                                           \n",
+       "2618  CryptoWorldCon, the Largest Conference Focused on Blockchain, Crypto, NFT, Metaverse, Bitcoin, Will Be Happening in Miami   \n",
+       "1766  Bitcoin could form the backbone for CBDCs, according to a new report                                                        \n",
+       "1869  Trust Through Verification: The Establishment’s Nightmare                                                                   \n",
+       "2170  Why Bitcoin- And Ethereum-Related Stock Marqeta Is Skyrocketing During Wednesday's After-Hours Session                      \n",
+       "3220  Bitcoin and Stock Futures Feel Choppy Following Heightened Russia-Ukraine Dispute                                           \n",
+       "\n",
+       "      has_verb predicted_sentiment  Negative   Neutral  Positive  pred_entropy  \n",
+       "2845  True      Positive            0.332262  0.329662  0.338076  1.098557      \n",
+       "3140  True      Negative            0.345230  0.320690  0.334080  1.098159      \n",
+       "226   True      Positive            0.330857  0.321662  0.347481  1.098100      \n",
+       "1822  True      Positive            0.322409  0.328323  0.349268  1.098018      \n",
+       "3143  True      Neutral             0.317704  0.348848  0.333448  1.097884      \n",
+       "2618  True      Neutral             0.336844  0.349672  0.313485  1.097597      \n",
+       "1766  True      Positive            0.315996  0.329612  0.354392  1.097481      \n",
+       "1869  True      Positive            0.329217  0.315983  0.354800  1.097450      \n",
+       "2170  True      Neutral             0.316709  0.356757  0.326534  1.097316      \n",
+       "3220  True      Neutral             0.311400  0.355290  0.333310  1.097167      "
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df_filtered.sort_values(by='pred_entropy', ascending=False).head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at examples with lowest prediction entropy, these are cases where the model is very confident about the prediction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Title</th>\n",
+       "      <th>has_verb</th>\n",
+       "      <th>predicted_sentiment</th>\n",
+       "      <th>Negative</th>\n",
+       "      <th>Neutral</th>\n",
+       "      <th>Positive</th>\n",
+       "      <th>pred_entropy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2999</th>\n",
+       "      <td>Bitcoin drops 8% and other cryptocurrencies tumble after Russia attacks Ukraine</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.988761</td>\n",
+       "      <td>0.003519</td>\n",
+       "      <td>0.007721</td>\n",
+       "      <td>0.068608</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2369</th>\n",
+       "      <td>Market Watch: Bitcoin Dips Below $38K, Fantom (FTM) Tumbles 15% Following Andre Cronje’s Leave</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.984598</td>\n",
+       "      <td>0.008657</td>\n",
+       "      <td>0.006745</td>\n",
+       "      <td>0.090116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1667</th>\n",
+       "      <td>NFT Weekly Sales Volume Improves Jumping 17% Higher Than the Week Prior – Bitcoin News</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.007534</td>\n",
+       "      <td>0.009584</td>\n",
+       "      <td>0.982882</td>\n",
+       "      <td>0.098345</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>376</th>\n",
+       "      <td>4 Cryptos to Buy as Bitcoin Surges Higher</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.012881</td>\n",
+       "      <td>0.005468</td>\n",
+       "      <td>0.981651</td>\n",
+       "      <td>0.102719</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3006</th>\n",
+       "      <td>Bitcoin price falls after Russia attacks Ukraine</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.980997</td>\n",
+       "      <td>0.007802</td>\n",
+       "      <td>0.011201</td>\n",
+       "      <td>0.107001</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2078</th>\n",
+       "      <td>Bitcoin cashpoints forced to shut down after being declared illegal</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.979825</td>\n",
+       "      <td>0.006901</td>\n",
+       "      <td>0.013274</td>\n",
+       "      <td>0.111682</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2764</th>\n",
+       "      <td>Kazakhstan government shuts down 13 illegal Bitcoin mines</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.979890</td>\n",
+       "      <td>0.010627</td>\n",
+       "      <td>0.009484</td>\n",
+       "      <td>0.112375</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1037</th>\n",
+       "      <td>Bitcoin climbs to highest value in 2022 and sees market cap hit $900bn</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.012840</td>\n",
+       "      <td>0.007531</td>\n",
+       "      <td>0.979628</td>\n",
+       "      <td>0.112904</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1714</th>\n",
+       "      <td>Bitcoin price holds above $40,000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.014440</td>\n",
+       "      <td>0.006229</td>\n",
+       "      <td>0.979331</td>\n",
+       "      <td>0.113280</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3000</th>\n",
+       "      <td>Bitcoin's price falls after Russia attacks Ukraine</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.977968</td>\n",
+       "      <td>0.011486</td>\n",
+       "      <td>0.010546</td>\n",
+       "      <td>0.121097</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                               Title  \\\n",
+       "2999  Bitcoin drops 8% and other cryptocurrencies tumble after Russia attacks Ukraine                  \n",
+       "2369  Market Watch: Bitcoin Dips Below $38K, Fantom (FTM) Tumbles 15% Following Andre Cronje’s Leave   \n",
+       "1667  NFT Weekly Sales Volume Improves Jumping 17% Higher Than the Week Prior – Bitcoin News           \n",
+       "376   4 Cryptos to Buy as Bitcoin Surges Higher                                                        \n",
+       "3006  Bitcoin price falls after Russia attacks Ukraine                                                 \n",
+       "2078  Bitcoin cashpoints forced to shut down after being declared illegal                              \n",
+       "2764  Kazakhstan government shuts down 13 illegal Bitcoin mines                                        \n",
+       "1037  Bitcoin climbs to highest value in 2022 and sees market cap hit $900bn                           \n",
+       "1714  Bitcoin price holds above $40,000                                                                \n",
+       "3000  Bitcoin's price falls after Russia attacks Ukraine                                               \n",
+       "\n",
+       "      has_verb predicted_sentiment  Negative   Neutral  Positive  pred_entropy  \n",
+       "2999  True      Negative            0.988761  0.003519  0.007721  0.068608      \n",
+       "2369  True      Negative            0.984598  0.008657  0.006745  0.090116      \n",
+       "1667  True      Positive            0.007534  0.009584  0.982882  0.098345      \n",
+       "376   True      Positive            0.012881  0.005468  0.981651  0.102719      \n",
+       "3006  True      Negative            0.980997  0.007802  0.011201  0.107001      \n",
+       "2078  True      Negative            0.979825  0.006901  0.013274  0.111682      \n",
+       "2764  True      Negative            0.979890  0.010627  0.009484  0.112375      \n",
+       "1037  True      Positive            0.012840  0.007531  0.979628  0.112904      \n",
+       "1714  True      Positive            0.014440  0.006229  0.979331  0.113280      \n",
+       "3000  True      Negative            0.977968  0.011486  0.010546  0.121097      "
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df_filtered.sort_values(by='pred_entropy', ascending=True).head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "521"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(test_df_filtered[test_df_filtered['pred_entropy'] > 1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Selecting data for annotation\n",
+    "\n",
+    "For annotation, we select 300 \"hard\" cases and 100 \"easy\" cases. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_df = pd.concat([test_df_filtered[test_df_filtered['pred_entropy'] <= 0.6].sample(300, random_state=17),\n",
+    "                      test_df_filtered[test_df_filtered['pred_entropy'] > 1].sample(100, random_state=17)])\\\n",
+    "            .sample(frac=1, random_state=17).reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "400"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sample_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Title</th>\n",
+       "      <th>has_verb</th>\n",
+       "      <th>predicted_sentiment</th>\n",
+       "      <th>Negative</th>\n",
+       "      <th>Neutral</th>\n",
+       "      <th>Positive</th>\n",
+       "      <th>pred_entropy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Luna Foundation Guard raises $1 billion to form bitcoin reserve for UST stablecoin</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.041531</td>\n",
+       "      <td>0.033519</td>\n",
+       "      <td>0.924950</td>\n",
+       "      <td>0.318102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Mexico Is Going to Accept Bitcoin</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.019635</td>\n",
+       "      <td>0.014969</td>\n",
+       "      <td>0.965396</td>\n",
+       "      <td>0.174069</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Titans become first NFL team to accept Bitcoin as payment</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.037177</td>\n",
+       "      <td>0.009850</td>\n",
+       "      <td>0.952973</td>\n",
+       "      <td>0.213803</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Warrant arrest Bitcoin scam targeting registered sex offenders in Mat-Su</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Negative</td>\n",
+       "      <td>0.940806</td>\n",
+       "      <td>0.017296</td>\n",
+       "      <td>0.041898</td>\n",
+       "      <td>0.260503</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Celsius Unveils Wrapped Bitcoin at Bitcoin 2022</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Positive</td>\n",
+       "      <td>0.189047</td>\n",
+       "      <td>0.304545</td>\n",
+       "      <td>0.506407</td>\n",
+       "      <td>1.021559</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                Title  \\\n",
+       "0  Luna Foundation Guard raises $1 billion to form bitcoin reserve for UST stablecoin   \n",
+       "1  Mexico Is Going to Accept Bitcoin                                                    \n",
+       "2  Titans become first NFL team to accept Bitcoin as payment                            \n",
+       "3  Warrant arrest Bitcoin scam targeting registered sex offenders in Mat-Su             \n",
+       "4  Celsius Unveils Wrapped Bitcoin at Bitcoin 2022                                      \n",
+       "\n",
+       "   has_verb predicted_sentiment  Negative   Neutral  Positive  pred_entropy  \n",
+       "0  True      Positive            0.041531  0.033519  0.924950  0.318102      \n",
+       "1  True      Positive            0.019635  0.014969  0.965396  0.174069      \n",
+       "2  True      Positive            0.037177  0.009850  0.952973  0.213803      \n",
+       "3  True      Negative            0.940806  0.017296  0.041898  0.260503      \n",
+       "4  True      Positive            0.189047  0.304545  0.506407  1.021559      "
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_df.head(200)['Title'].to_csv('../data/20120413_sample_to_annotate_batch_1.csv', index=None)\n",
+    "sample_df.tail(200)['Title'].to_csv('../data/20120413_sample_to_annotate_batch_2.csv', index=None)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Here I'm scraping https://bitcointicker.co/news/ and running the model against this data to select diverse examples (when the model is very confident and when it's lost) to be annotated with Amazon Mechanical Turk.

Results
- 3250 news titles are saved locally. Of those 2 batches, each of 200 records, are selected for annotation.
- Filtering based on the presence of at least one verb seems to make sense
- Prediction entropy works well to distinguish between easy and hard examples but some hard examples seem to be rubbish